### PR TITLE
Defining the Sass function parameters automatically

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -10,6 +10,7 @@ module.exports = {
 		]
 	],
 	plugins: [
+		'@babel/plugin-proposal-class-properties',
 		'@babel/plugin-transform-modules-commonjs'
 	]
 };

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Output:
 }
 ```
 
-##### It works also with spread arguments
+##### It works also with spread parameters
 
 ```js
 const path = require('path');

--- a/README.md
+++ b/README.md
@@ -37,6 +37,99 @@ This package contains a class (JSFunctionsToSass), which acts like a middleware 
 
 Both **sync** and **async** functions are supported.
 
+#### Easy syntax
+
+JSFunctionsToSass makes it possible to automatically define the parameters of the Sass function.
+
+If the Sass function signature (the _keys_ of the Sass `options.functions` object) doesn't have a parameter block, it tries to get the parameter names of the JS function, and define the same parameter names also in the Sass function. If we cannot get the parameter names of the given JS function (most probably it doesn't have explicitly declared parameters), we add a single spread parameter for the Sass function (`$arguments...`), making it possible to wrap JS functions which use eg. `arguments` in their body.
+
+This functionality is limited only to Sass function signatures **without a parameter block** (parentheses immediately after the function's name). Sass functions _having_ defined parameters remain untouched, and the same applies if explicitly zero parameters are defined (when the parameter block is empty).
+
+**Note:** `JSFunctionsToSass` cannot detect (and therefore define) the _default values_ of the function parameters. If Sass throws error because of a missing (but only optional) argument, you can fall back anytime to the original Sass signature syntax.
+
+The automatic parameter resolution is completely optional and can be used in parallel with the original syntax.
+
+
+### Default syntax
+
+```js
+const path = require('path');
+const sass = require('node-sass');
+const { JSFunctionsToSass } = require('jsass/dist/node');
+const jsFunctionsToSass = new JSFunctionsToSass();
+
+sass.render({
+  file: path.resolve('styles.scss'),
+  functions: jsFunctionsToSass.convert({
+    // Explicitly defined Sass parameter names
+    'str-replace($string, $search, $replace: "")': function str_replace(string, search, replace) {
+      if (typeof string !== 'string') {
+        throw new Error('str-replace needs `$string` to be typeof string!');
+      }
+      return string.replace(new RegExp(search, 'g'), replace);
+    }
+  })
+}, (err, result) => {
+  if (err) {
+    throw new Error(err);
+  }
+
+  console.log(result.css.toString());
+});
+```
+
+### Easier syntax
+
+```js
+const path = require('path');
+const sass = require('node-sass');
+const { JSFunctionsToSass } = require('jsass/dist/node');
+const jsFunctionsToSass = new JSFunctionsToSass();
+
+sass.render({
+  file: path.resolve('styles.scss'),
+  functions: jsFunctionsToSass.convert({
+    // Sass parameter names resolved from the JS function
+    str_replace: function str_replace(string, search, replace) {
+      if (typeof string !== 'string') {
+        throw new Error('str-replace needs `$string` to be typeof string!');
+      }
+      return string.replace(new RegExp(search, 'g'), replace);
+    }
+  })
+}, (err, result) => {
+  if (err) {
+    throw new Error(err);
+  }
+
+  console.log(result.css.toString());
+});
+```
+
+### Syntax sugar
+
+```js
+const path = require('path');
+const sass = require('node-sass');
+const { JSFunctionsToSass } = require('jsass/dist/node');
+const jsFunctionsToSass = new JSFunctionsToSass();
+const str_replace = require('./str_replace');
+
+sass.render({
+  file: path.resolve('styles.scss'),
+  functions: jsFunctionsToSass.convert({
+    // Passing only a JS function reference
+    str_replace
+  })
+}, (err, result) => {
+  if (err) {
+    throw new Error(err);
+  }
+
+  console.log(result.css.toString());
+});
+```
+
 #### Examples
 ##### Implementing missing in Sass `str-replace` function
 
@@ -52,7 +145,7 @@ const jsFunctionsToSass = new JSFunctionsToSass();
 sass.render({
   file: path.resolve(__dirname, './str-replace.scss'),
   functions: jsFunctionsToSass.convert({
-    'str-replace($string, $search, $replace: "")': function (string, search, replace) {
+    'str-replace': function (string, search, replace) {
       if (typeof string !== 'string') {
         throw new Error('str-replace needs `$string` to be typeof string!');
       }
@@ -143,7 +236,7 @@ Output:
 }
 ```
 
-##### It works also with spread parameters
+##### It works also with arbitrary (spread) arguments
 
 ```js
 const path = require('path');

--- a/examples/jsFunctionsToSass/str-replace.js
+++ b/examples/jsFunctionsToSass/str-replace.js
@@ -11,7 +11,8 @@ console.log('\nAdding a `str-replace` function to Sass\n');
 sass.render({
   file: path.resolve(__dirname, './str-replace.scss'),
   functions: jsFunctionsToSass.convert({
-    'str-replace($string, $search, $replace: "")': function (string, search, replace) {
+    // Read more about the syntax possibilities in https://github.com/body-builder/jsass#easy-syntax
+    str_replace: function str_replace(string, search, replace) {
       if (typeof string !== 'string') {
         throw new Error('str-replace needs `$string` to be typeof string!');
       }

--- a/examples/jsFunctionsToSass/url-join.js
+++ b/examples/jsFunctionsToSass/url-join.js
@@ -13,7 +13,8 @@ console.log('\nAdding a `url-join` function to Sass, using the `url-join` NPM pa
 sass.render({
   file: path.resolve(__dirname, './url-join.scss'),
   functions: jsFunctionsToSass.convert({
-    'url-join($paths...)': urljoin
+    // Read more about the syntax possibilities in https://github.com/body-builder/jsass#easy-syntax
+    urljoin
   })
 }, (err, result) => {
   if (err) {

--- a/examples/jsFunctionsToSass/url-join.scss
+++ b/examples/jsFunctionsToSass/url-join.scss
@@ -1,4 +1,4 @@
 .url-join {
   content: '#{('https://', 'github.com', 'body-builder', 'jsass')}';
-  content-joined: '#{url-join('https://', 'github.com', 'body-builder', 'jsass')}';
+  content-joined: '#{urljoin('https://', 'github.com', 'body-builder', 'jsass')}';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,6 +111,20 @@
         "@babel/types": "^7.7.0"
       }
     },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.7.0.tgz",
+      "integrity": "sha512-MZiB5qvTWoyiFOgootmRSDV1udjIqJW/8lmxgzKq6oDqxdmHUjeP2ZUOmgHdYjmUVNABqRrHjYAYRvj8Eox/UA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.7.0",
+        "@babel/helper-member-expression-to-functions": "^7.7.0",
+        "@babel/helper-optimise-call-expression": "^7.7.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.7.0",
+        "@babel/helper-split-export-declaration": "^7.7.0"
+      }
+    },
     "@babel/helper-create-regexp-features-plugin": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.2.tgz",
@@ -335,6 +349,16 @@
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-remap-async-to-generator": "^7.7.0",
         "@babel/plugin-syntax-async-generators": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.7.0.tgz",
+      "integrity": "sha512-tufDcFA1Vj+eWvwHN+jvMN6QsV5o+vUlytNKrbMiCeDL0F2j92RURzUsUMWE5EJkLyWxjdUslCsMQa9FWth16A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.7.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-proposal-dynamic-import": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@babel/cli": "^7.7.0",
     "@babel/core": "^7.7.2",
     "@babel/node": "^7.7.0",
+    "@babel/plugin-proposal-class-properties": "^7.7.0",
     "@babel/plugin-transform-modules-commonjs": "^7.7.0",
     "@babel/preset-env": "^7.7.1",
     "babel-eslint": "^10.0.3",

--- a/src/JSFunctionsToSass.js
+++ b/src/JSFunctionsToSass.js
@@ -60,11 +60,12 @@ class JSFunctionsToSass {
 
 	/**
 	 * Parses the Sass function declaration string and returns the extracted information in an Object
-	 * @param key The Sass function declaration string (the `key` of the Sass `options.functions` object), eg: 'headings($from: 0, $to: 6)'
+	 * @param sass_decl The Sass function declaration string (the `key` of the Sass `options.functions` object), eg: 'headings($from: 0, $to: 6)'
 	 * @returns {null|{name: string, args: string[], spreadArgs: number[]}}
+	 * @private
 	 */
-	_getSassFunctionData(key) {
-		const matches = key.replace(')', '').split('(');
+	_getSassFunctionData(sass_decl) {
+		const matches = sass_decl.replace(')', '').split('(');
 
 		// The name of the Sass function
 		const name = matches[0];
@@ -76,15 +77,11 @@ class JSFunctionsToSass {
 		const spreadArgs = [];
 		args.forEach((arg, index) => arg.endsWith('...') && spreadArgs.push(index));
 
-		if (name) {
-			return {
-				name,
-				args,
-				spreadArgs
-			};
-		} else {
-			return null;
-		}
+		return {
+			name,
+			args,
+			spreadArgs
+		};
 	}
 
 	/**
@@ -98,6 +95,14 @@ class JSFunctionsToSass {
 		return (error instanceof Error) ? error : new Error(error);
 	}
 
+	/**
+	 * @param sass_decl The Sass function declaration string (the `key` of the Sass `options.functions` object), eg: 'headings($from: 0, $to: 6)'
+	 * @param fn The Javascript function to be called (the `value` of the Sass `options.functions` object)
+	 * @param args The Array of the arguments which has been applied to `fn` by Sass. These are the Sass type arguments
+	 * @param options Option overrides for the current JSFunctionsToSass instance
+	 * @returns {*}
+	 * @private
+	 */
 	_wrapFunction(sass_decl, fn, args = [], options) {
 		if (kindOf(fn) !== 'function') {
 			throw new Error('JSFunctionsToSass - pass a function to wrapFunction!');
@@ -159,6 +164,12 @@ class JSFunctionsToSass {
 		}
 	}
 
+	/**
+	 * Processes the Object passed in Sass's `options.functions`. This is the main method, which will be called with the instance's `convert()` method.
+	 * @param obj The `functions` property of the Sass options, which contains the function declarations (see the Sass documentation in https://sass-lang.com/documentation/js-api#functions)
+	 * @param options Option overrides for the current JSFunctionsToSass instance
+	 * @private
+	 */
 	_wrapObject(obj, options) {
 		if (kindOf(obj) !== 'object') {
 			throw new Error('JSFunctionsToSass - pass an object in the following format:\n{\n  \'sass-fn-name($arg1: 0, $arg2: 6)\': function(arg1, arg2) {\n    ...\n  }\n}'); // prettier-ignore

--- a/src/JSFunctionsToSass.js
+++ b/src/JSFunctionsToSass.js
@@ -5,11 +5,11 @@ const SassVarsToJS = require('./SassVarsToJS');
 class JSFunctionsToSass {
 	// Credits to Jack Allan (https://stackoverflow.com/a/9924463/3111787)
 	static STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
-	static ARGUMENT_NAMES = /([^\s,]+)/g;
+	static PARAMETER_NAMES = /([^\s,]+)/g;
 
-	static getFunctionArgs(func) {
+	static getFunctionParams(func) {
 		const fnStr = func.toString().replace(this.STRIP_COMMENTS, '');
-		const result = fnStr.slice(fnStr.indexOf('(') + 1, fnStr.indexOf(')')).match(this.ARGUMENT_NAMES);
+		const result = fnStr.slice(fnStr.indexOf('(') + 1, fnStr.indexOf(')')).match(this.PARAMETER_NAMES);
 
 		return result || [];
 	}
@@ -30,50 +30,50 @@ class JSFunctionsToSass {
 	}
 
 	/**
-	 * Parses the Sass function declaration string and auto-fills the argument declaration block in it (only if even the parentheses are missing)
-	 * @param sass_decl The Sass function declaration string (the `key` of the Sass `options.functions` object), eg: 'headings($from: 0, $to: 6)'
+	 * Parses the Sass function signature and generates the parameter declaration block in it (only if even the parentheses are missing)
+	 * @param signature The Sass function signature string (the `key` of the Sass `options.functions` object), eg: 'headings($from: 0, $to: 6)'
 	 * @param fn
 	 * @returns {*}
 	 * @private
 	 */
-	_resolveSassDeclarationArguments(sass_decl, fn) {
-		if (kindOf(sass_decl) !== 'string') {
-			throw new Error('JSFunctionsToSass - pass the Sass function declaration to _resolveSassDeclarationArguments!');
+	_createSassParameterBlock(signature, fn) {
+		if (kindOf(signature) !== 'string') {
+			throw new Error('JSFunctionsToSass - pass the Sass function signature to _createSassParameterBlock!');
 		}
 
-		// Do not do anything if arguments are already defined (even if the parenthesis is empty - that may be a valid, intentional use-case)
-		if (sass_decl.indexOf('(') > -1 && sass_decl.indexOf(')') > -1) {
-			return sass_decl;
+		// Do not do anything if parameters are already defined (even if the parenthesis is empty - that may be a valid, intentional use-case)
+		if (signature.indexOf('(') > -1 && signature.indexOf(')') > -1) {
+			return signature;
 		}
 
-		const js_fn_arguments = this.constructor.getFunctionArgs(fn);
+		const js_fn_params = this.constructor.getFunctionParams(fn);
 
-		let argument_decl;
-		if (js_fn_arguments.length) {
-			argument_decl = js_fn_arguments.map((item) => `$${item}`).join(', ');
+		let sass_params;
+		if (js_fn_params.length) {
+			sass_params = js_fn_params.map((item) => `$${item}`).join(', ');
 		} else {
-			argument_decl = '$arguments...';
+			sass_params = '$arguments...';
 		}
 
-		return `${sass_decl}(${argument_decl})`;
+		return `${signature}(${sass_params})`;
 	}
 
 	/**
-	 * Parses the Sass function declaration string and returns the extracted information in an Object
-	 * @param sass_decl The Sass function declaration string (the `key` of the Sass `options.functions` object), eg: 'headings($from: 0, $to: 6)'
+	 * Parses the Sass function signature and returns the extracted information in an Object
+	 * @param signature The Sass function signature string (the `key` of the Sass `options.functions` object), eg: 'headings($from: 0, $to: 6)'
 	 * @returns {null|{name: string, args: string[], spreadArgs: number[]}}
 	 * @private
 	 */
-	_getSassFunctionData(sass_decl) {
-		const matches = sass_decl.replace(')', '').split('(');
+	_getSassFunctionData(signature) {
+		const matches = signature.replace(')', '').split('(');
 
 		// The name of the Sass function
 		const name = matches[0];
 
-		// The list of the arguments
+		// The list of the parameters
 		const args = matches[1].split(',');
 
-		// The indexes of the arguments, which accepts spread content. This is important, as we also
+		// The indexes of the parameters, which accepts spread content. This is important, as we also
 		const spreadArgs = [];
 		args.forEach((arg, index) => arg.endsWith('...') && spreadArgs.push(index));
 
@@ -96,14 +96,14 @@ class JSFunctionsToSass {
 	}
 
 	/**
-	 * @param sass_decl The Sass function declaration string (the `key` of the Sass `options.functions` object), eg: 'headings($from: 0, $to: 6)'
+	 * @param signature The Sass function signature (the `key` of the Sass `options.functions` object), eg: 'headings($from: 0, $to: 6)'
 	 * @param fn The Javascript function to be called (the `value` of the Sass `options.functions` object)
 	 * @param args The Array of the arguments which has been applied to `fn` by Sass. These are the Sass type arguments
 	 * @param options Option overrides for the current JSFunctionsToSass instance
 	 * @returns {*}
 	 * @private
 	 */
-	_wrapFunction(sass_decl, fn, args = [], options) {
+	_wrapFunction(signature, fn, args = [], options) {
 		if (kindOf(fn) !== 'function') {
 			throw new Error('JSFunctionsToSass - pass a function to wrapFunction!');
 		}
@@ -114,7 +114,7 @@ class JSFunctionsToSass {
 
 		options = Object.assign({}, this._options, options);
 
-		const sassFunctionData = this._getSassFunctionData(sass_decl);
+		const sassFunctionData = this._getSassFunctionData(signature);
 
 		// Sass' asynchronous `render()` provides an additional callback as the last argument, to which we can asynchronously pass the result of the function when it’s complete.
 		// We need to separate this callback from the Sass-type arguments. (`node-sass` provides a `CallbackBridge' type in synchronous mode, which we also need to separate from the Sass-type arguments.)
@@ -132,7 +132,7 @@ class JSFunctionsToSass {
 		sassTypeArgs.forEach((sassTypeArg, index) => {
 			const jsTypeArg = this._sassVarsToJS._convert(sassTypeArg, options);
 
-			// If the Sass function expects the data to be spread for the current argument, we spread the arguments also for the JS function.
+			// If the Sass function expects the arguments to be spread for the current parameter, we spread the arguments also for the JS function.
 			if (kindOf(jsTypeArg) === 'array' && sassFunctionData.spreadArgs.indexOf(index) !== -1) {
 				jsTypeArgs.push(...jsTypeArg);
 			} else {
@@ -166,7 +166,7 @@ class JSFunctionsToSass {
 
 	/**
 	 * Processes the Object passed in Sass's `options.functions`. This is the main method, which will be called with the instance's `convert()` method.
-	 * @param obj The `functions` property of the Sass options, which contains the function declarations (see the Sass documentation in https://sass-lang.com/documentation/js-api#functions)
+	 * @param obj The `functions` property of the Sass options, which contains the function signatures (see the Sass documentation in https://sass-lang.com/documentation/js-api#functions)
 	 * @param options Option overrides for the current JSFunctionsToSass instance
 	 * @private
 	 */
@@ -182,13 +182,13 @@ class JSFunctionsToSass {
 		Object.keys(obj).forEach((key, index) => {
 			const fn = obj[key];
 
-			const sass_decl = this._resolveSassDeclarationArguments(key, fn);
+			const signature = this._createSassParameterBlock(key, fn);
 
 			if (kindOf(fn) !== 'function') {
 				throw new Error('JSFunctionsToSass - pass a function to wrapObject!');
 			}
 
-			newObj[sass_decl] = (...args) => this._wrapFunction(sass_decl, fn, args, options);
+			newObj[signature] = (...args) => this._wrapFunction(signature, fn, args, options);
 		});
 
 		return newObj;

--- a/src/JSVarsToSassData.js
+++ b/src/JSVarsToSassData.js
@@ -132,8 +132,8 @@ class JSVarsToSassData extends JSVarsToSass {
 	 * The main query, which iterates over the values, collects the _createVariable() responses to a JS array, and returns it as string joined with newlines.
 	 *
 	 * Accepts two syntaxes:
-	 *  - 3 parameters: key, value, [options]
-	 *  - 2 parameters: { key: value }, [options]
+	 *  - 3 arguments: key, value, [options]
+	 *  - 2 arguments: { key: value }, [options]
 	 *
 	 * @param values
 	 * @param options

--- a/tests/jsFunctionsToSass.node.spec.js
+++ b/tests/jsFunctionsToSass.node.spec.js
@@ -18,7 +18,7 @@ describe_implementation('jsFunctionsToSass', function(sass) {
 	const jsFunctionsToSass = new JSFunctionsToSass({ implementation: sass });
 
 	it('Should throw error if calling with wrong arguments', function() {
-		expect(() => jsFunctionsToSass._resolveSassDeclarationArguments()).toThrow(new Error('JSFunctionsToSass - pass the Sass function declaration to _resolveSassDeclarationArguments!'));
+		expect(() => jsFunctionsToSass._createSassParameterBlock()).toThrow(new Error('JSFunctionsToSass - pass the Sass function signature to _createSassParameterBlock!'));
 		expect(() => jsFunctionsToSass._wrapFunction('sass-fn($arg)')).toThrow(new Error('JSFunctionsToSass - pass a function to wrapFunction!'));
 		expect(() => jsFunctionsToSass._wrapObject()).toThrow(new Error('JSFunctionsToSass - pass an object in the following format:\n{\n  \'sass-fn-name($arg1: 0, $arg2: 6)\': function(arg1, arg2) {\n    ...\n  }\n}'));
 		expect(() => jsFunctionsToSass.convert()).toThrow(new Error('JSFunctionsToSass - pass an object in the following format:\n{\n  \'sass-fn-name($arg1: 0, $arg2: 6)\': function(arg1, arg2) {\n    ...\n  }\n}'));
@@ -253,7 +253,7 @@ describe_implementation('jsFunctionsToSass', function(sass) {
 		expect(selectedProp(new sass.types.String('async'), new sass.types.Number(3), () => 'done').getValue()).toEqual(new sass.types.String('async async async').getValue());
 	});
 
-	describe('Should handle spread arguments correctly', function() {
+	describe('Should handle spread parameters correctly', function() {
 		let spy_spread_args, spy_spread_string_args, spy_no_spread_args;
 		const list = new sass.types.List(2);
 		list.setValue(0, new sass.types.String('string'));
@@ -276,7 +276,7 @@ describe_implementation('jsFunctionsToSass', function(sass) {
 			expect(kindOf(spy_spread_string_args[1])).toEqual('undefined');
 		});
 
-		it('Should spread only if the Sass function declaration contains spread argument', function() {
+		it('Should spread only if the Sass function signature contains spread parameter', function() {
 			expect(kindOf(spy_no_spread_args[0])).toEqual('array');
 			expect(kindOf(spy_no_spread_args[0][0])).toEqual('string');
 			expect(spy_no_spread_args[0][0]).toEqual('string');
@@ -329,8 +329,8 @@ describe_implementation('jsFunctionsToSass', function(sass) {
 		});
 	});
 
-	describe('Simpler syntax for Sass function declaration', function() {
-		it('Should resolve the argument name correctly', async function() {
+	describe('Simpler syntax for Sass function signature', function() {
+		it('Should resolve the parameter name correctly', async function() {
 			const wrappedObject = jsFunctionsToSass.convert({
 				a_b_c: (a, b, c) => JSON.stringify({ a, b, c })
 			});
@@ -365,7 +365,7 @@ describe_implementation('jsFunctionsToSass', function(sass) {
 			expect(result3.css.toString().trim()).toEqual('.test {\n  content: \'{"a":1,"b":3,"c":2}\';\n}');
 		});
 
-		it('Should add a single _spread_ Sass argument if no arguments found in the JS function', async function() {
+		it('Should add a single _spread_ Sass parameter if no parameters found in the JS function', async function() {
 			const wrappedObject = jsFunctionsToSass.convert({
 				spread_arguments: function() {
 					return JSON.stringify([...arguments]);
@@ -383,7 +383,7 @@ describe_implementation('jsFunctionsToSass', function(sass) {
 			expect(result.css.toString().trim()).toEqual('.test {\n  content: "[1,2,3]";\n}');
 		});
 
-		it('Should resolve the name and the arguments only from a function reference', function() {
+		it('Should resolve the name and the parameters only from a function reference', function() {
 			const function_reference = (a, b, c) => {},
 				function_reference_no_arguments = () => {};
 
@@ -396,7 +396,7 @@ describe_implementation('jsFunctionsToSass', function(sass) {
 			expect(Object.keys(wrappedObject)).toContain('function_reference_no_arguments($arguments...)');
 		});
 
-		it('Should keep the already defined argument blocks untouched', function() {
+		it('Should keep the already defined parameters untouched', function() {
 			const wrappedObject = jsFunctionsToSass.convert({
 				'has_arguments($str, $number)': (a, b, c) => {},
 				'no_arguments()': (a, b, c) => {},

--- a/tests/jsVarsToSassData.node.spec.js
+++ b/tests/jsVarsToSassData.node.spec.js
@@ -5,7 +5,7 @@ describe_implementation('jsVarsToSassData', function(sass) {
 		implementation: sass
 	});
 
-	it('Should handle both the 3-parameters and the 2-parameters syntax', function() {
+	it('Should handle both the 3-arguments and the 2-arguments syntax', function() {
 		expect(jsVarsToSassData.convert('number', 0.454)).toEqual('$number: 0.454;');
 		expect(jsVarsToSassData.convert({ number: 0.454 })).toEqual('$number: 0.454;');
 	});


### PR DESCRIPTION
This PR adds the possibility to use an easier syntax for `JSFunctionsToSass`, allowing it to automatically define the parameters of the Sass function.

If the Sass function signature (the _keys_ of the Sass `options.functions` object) doesn't have a parameter block, it tries to get the parameter names of the JS function with RegExp, and define the same parameter names also in the Sass function. If we cannot get the parameter names of the given JS function (most probably it doesn't have explicitly declared parameters), we add a single spread parameter for the Sass function (`$arguments...`), making it possible to wrap JS functions which use eg. `arguments` in their body.

This functionality is limited only to Sass function signatures **without a parameter block** (parentheses immediately after the function's name). Sass functions _having_ defined parameters remain untouched, and the same applies if explicitly zero parameters are defined (when the parameter block is empty).

**Note:** `JSFunctionsToSass` cannot detect (and therefore define) the _default values_ of the function parameters. If Sass throws error because of a missing (but only optional) argument, you can fall back anytime to the original Sass signature syntax.

The automatic parameter resolution is completely optional and can be used in parallel with the original syntax.

### Original syntax (still available)

```js
const path = require('path');
const sass = require('node-sass');
const { JSFunctionsToSass } = require('jsass/dist/node');
const jsFunctionsToSass = new JSFunctionsToSass();

sass.render({
  file: path.resolve('styles.scss'),
  functions: jsFunctionsToSass.convert({
    // Explicitly defined Sass parameter names
    'str-replace($string, $search, $replace: "")': function str_replace(string, search, replace) {
      if (typeof string !== 'string') {
        throw new Error('str-replace needs `$string` to be typeof string!');
      }
      return string.replace(new RegExp(search, 'g'), replace);
    }
  })
}, (err, result) => {
  if (err) {
    throw new Error(err);
  }

  console.log(result.css.toString());
});
```

### Easier syntax

```js
const path = require('path');
const sass = require('node-sass');
const { JSFunctionsToSass } = require('jsass/dist/node');
const jsFunctionsToSass = new JSFunctionsToSass();

sass.render({
  file: path.resolve('styles.scss'),
  functions: jsFunctionsToSass.convert({
    // Sass parameter names resolved from the JS function
    str_replace: function str_replace(string, search, replace) {
      if (typeof string !== 'string') {
        throw new Error('str-replace needs `$string` to be typeof string!');
      }
      return string.replace(new RegExp(search, 'g'), replace);
    }
  })
}, (err, result) => {
  if (err) {
    throw new Error(err);
  }

  console.log(result.css.toString());
});
```

### Syntax sugar

```js
const path = require('path');
const sass = require('node-sass');
const { JSFunctionsToSass } = require('jsass/dist/node');
const jsFunctionsToSass = new JSFunctionsToSass();
const str_replace = require('./str_replace');

sass.render({
  file: path.resolve('styles.scss'),
  functions: jsFunctionsToSass.convert({
    // Passing only a JS function reference
    str_replace
  })
}, (err, result) => {
  if (err) {
    throw new Error(err);
  }

  console.log(result.css.toString());
});
```

- [x] implementation
- [x] tests
- [x] documentation